### PR TITLE
Move cache grain dependencies to shared context

### DIFF
--- a/src/Outkeep.Core.Abstractions/Caching/CacheEntryExtensions.cs
+++ b/src/Outkeep.Core.Abstractions/Caching/CacheEntryExtensions.cs
@@ -86,9 +86,17 @@ namespace Outkeep.Core.Caching
         /// </summary>
         public static ICacheEntry ContinueWithOnEvicted(this ICacheEntry entry, Action<Task<CacheEvictionArgs>> action, CancellationToken cancellationToken = default)
         {
+            return ContinueWithOnEvicted(entry, action, out _, cancellationToken);
+        }
+
+        /// <summary>
+        /// Convenience method to schedule a continuation on the <see cref="ICacheEntry.Evicted"/> property using the current task scheduler.
+        /// </summary>
+        public static ICacheEntry ContinueWithOnEvicted(this ICacheEntry entry, Action<Task<CacheEvictionArgs>> action, out Task continuation, CancellationToken cancellationToken = default)
+        {
             if (entry == null) throw new ArgumentNullException(nameof(entry));
 
-            entry.Evicted.ContinueWith(action, cancellationToken, TaskContinuationOptions.DenyChildAttach, TaskScheduler.Current);
+            continuation = entry.Evicted.ContinueWith(action, cancellationToken, TaskContinuationOptions.DenyChildAttach, TaskScheduler.Current);
 
             return entry;
         }

--- a/src/Outkeep.Core.Abstractions/Caching/ICacheDirector.cs
+++ b/src/Outkeep.Core.Abstractions/Caching/ICacheDirector.cs
@@ -15,6 +15,13 @@
         ICacheEntry CreateEntry(string key, long size);
 
         /// <summary>
+        /// Attempts to get the entry with the specified key.
+        /// </summary>
+        /// <param name="key">The cache entry key.</param>
+        /// <returns>The cache entry with the specified key if found, otherwise <see cref="null"/></returns>
+        bool TryGetEntry(string key, out ICacheEntry? entry);
+
+        /// <summary>
         /// Gets the number of entries managed by this cache director.
         /// </summary>
         int Count { get; }

--- a/src/Outkeep.Core.Abstractions/TaskExtensions.cs
+++ b/src/Outkeep.Core.Abstractions/TaskExtensions.cs
@@ -21,8 +21,14 @@
             if (timeout == TimeSpan.Zero) return Task.FromResult(defaultValue);
 
             // slow path for regular completion
-            var delay = Task.Delay(timeout).ContinueWith((x, dv) => (T)dv, defaultValue, cancellationToken, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            var delay = Task.Delay(timeout, cancellationToken).ContinueWith(DelayAction, defaultValue, cancellationToken, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
             return Task.WhenAny(task, delay).Unwrap();
+
+            // called upon delay completion
+            static T DelayAction(Task t, object dv)
+            {
+                return (T)dv;
+            }
         }
     }
 }

--- a/src/Outkeep.Core/Caching/CacheDirector.cs
+++ b/src/Outkeep.Core/Caching/CacheDirector.cs
@@ -64,6 +64,21 @@ namespace Outkeep.Core.Caching
             return new CacheEntry(key, size, this);
         }
 
+        /// <inheritdoc />
+        public bool TryGetEntry(string key, out ICacheEntry? entry)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+
+            if (_entries.TryGetValue(key, out var value))
+            {
+                entry = value;
+                return true;
+            }
+
+            entry = null;
+            return false;
+        }
+
         /// <summary>
         /// Attempts to find and expire the item with the given key.
         /// </summary>

--- a/src/Outkeep.Core/ImmutableExtensions.cs
+++ b/src/Outkeep.Core/ImmutableExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace Orleans.Concurrency
+{
+    public static class ImmutableExtensions
+    {
+        public static Immutable<T?> AsNullableImmutable<T>(this T? value) where T : class
+        {
+            return new Immutable<T?>(value);
+        }
+    }
+}

--- a/src/Outkeep.Core/Storage/MemoryCacheStorageOutkeepServerBuilderExtensions.cs
+++ b/src/Outkeep.Core/Storage/MemoryCacheStorageOutkeepServerBuilderExtensions.cs
@@ -7,7 +7,7 @@ namespace Outkeep.Core
     /// <summary>
     /// Quality-of-life extensions for <see cref="IOutkeepServerBuilder"/>.
     /// </summary>
-    public static class OutkeepServerBuilderExtensions
+    public static class MemoryCacheStorageOutkeepServerBuilderExtensions
     {
         /// <summary>
         /// Adds a singleton <see cref="MemoryCacheStorage"/> to the <see cref="IOutkeepServerBuilder"/>.
@@ -19,19 +19,6 @@ namespace Outkeep.Core
             return builder.ConfigureServices((context, services) =>
             {
                 services.AddSingleton<ICacheStorage, MemoryCacheStorage>();
-            });
-        }
-
-        /// <summary>
-        /// Adds a singleton <see cref="NullCacheStorage"/> to the <see cref="IOutkeepServerBuilder"/>.
-        /// </summary>
-        public static IOutkeepServerBuilder AddNullCacheStorage(this IOutkeepServerBuilder builder)
-        {
-            if (builder is null) throw new ArgumentNullException(nameof(builder));
-
-            return builder.ConfigureServices((context, services) =>
-            {
-                services.AddSingleton<ICacheStorage, NullCacheStorage>();
             });
         }
     }

--- a/src/Outkeep.Core/Storage/MemoryCacheStorageServiceCollectionExtensions.cs
+++ b/src/Outkeep.Core/Storage/MemoryCacheStorageServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Outkeep.Core.Storage;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class MemoryCacheStorageServiceCollectionExtensions
+    {
+        public static IServiceCollection AddMemoryCacheStorage(this IServiceCollection services)
+        {
+            return services.AddSingleton<ICacheStorage, MemoryCacheStorage>();
+        }
+    }
+}

--- a/src/Outkeep.Core/Storage/NullCacheStorageOutkeepServerBuilderExtensions.cs
+++ b/src/Outkeep.Core/Storage/NullCacheStorageOutkeepServerBuilderExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Outkeep.Core.Storage;
+using System;
+
+namespace Outkeep.Core
+{
+    public static class NullCacheStorageOutkeepServerBuilderExtensions
+    {
+        /// <summary>
+        /// Adds a singleton <see cref="NullCacheStorage"/> to the <see cref="IOutkeepServerBuilder"/>.
+        /// </summary>
+        public static IOutkeepServerBuilder AddNullCacheStorage(this IOutkeepServerBuilder builder)
+        {
+            if (builder is null) throw new ArgumentNullException(nameof(builder));
+
+            return builder.ConfigureServices((context, services) =>
+            {
+                services.AddSingleton<ICacheStorage, NullCacheStorage>();
+            });
+        }
+    }
+}

--- a/src/Outkeep.Grains/CacheGrain.cs
+++ b/src/Outkeep.Grains/CacheGrain.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Orleans;
 using Orleans.Concurrency;
 using Orleans.Core;
@@ -18,17 +17,15 @@ namespace Outkeep.Grains
     internal class CacheGrain : Grain, ICacheGrain, IIncomingGrainCallFilter
     {
         private readonly ICacheGrainContext _context;
-        private readonly CacheGrainOptions _options;
         private readonly ICacheStorage _storage;
         private readonly ISystemClock _clock;
         private readonly IGrainIdentity _identity;
         private readonly ICacheDirector _director;
         private readonly ITimerRegistry _timers;
 
-        public CacheGrain(ICacheGrainContext context, IOptions<CacheGrainOptions> options, ICacheStorage storage, ISystemClock clock, IGrainIdentity identity, ICacheDirector director, ITimerRegistry timers)
+        public CacheGrain(ICacheGrainContext context, ICacheStorage storage, ISystemClock clock, IGrainIdentity identity, ICacheDirector director, ITimerRegistry timers)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
-            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             _storage = storage ?? throw new ArgumentNullException(nameof(storage));
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
             _identity = identity ?? throw new ArgumentNullException(nameof(identity));
@@ -278,7 +275,7 @@ namespace Outkeep.Grains
             // if there is no entry yet then return a promise
             if (_entry == null)
             {
-                return _promise.Task.WithDefaultOnTimeout(CachePulse.None, _options.ReactivePollingTimeout);
+                return _promise.Task.WithDefaultOnTimeout(CachePulse.None, _context.Options.ReactivePollingTimeout);
             }
 
             // if the current entry has expired then release it and return a clear pulse
@@ -295,7 +292,7 @@ namespace Outkeep.Grains
             if (tag == _pulse.Tag)
             {
                 // the caller already has the same data so return a promise
-                return _promise.Task.WithDefaultOnTimeout(CachePulse.None, _options.ReactivePollingTimeout);
+                return _promise.Task.WithDefaultOnTimeout(CachePulse.None, _context.Options.ReactivePollingTimeout);
             }
             else
             {

--- a/src/Outkeep.Grains/CacheGrain.cs
+++ b/src/Outkeep.Grains/CacheGrain.cs
@@ -17,18 +17,18 @@ namespace Outkeep.Grains
     [Reentrant]
     internal class CacheGrain : Grain, ICacheGrain, IIncomingGrainCallFilter
     {
+        private readonly ICacheGrainContext _context;
         private readonly CacheGrainOptions _options;
-        private readonly ILogger _logger;
         private readonly ICacheStorage _storage;
         private readonly ISystemClock _clock;
         private readonly IGrainIdentity _identity;
         private readonly ICacheDirector _director;
         private readonly ITimerRegistry _timers;
 
-        public CacheGrain(IOptions<CacheGrainOptions> options, ILogger<CacheGrain> logger, ICacheStorage storage, ISystemClock clock, IGrainIdentity identity, ICacheDirector director, ITimerRegistry timers)
+        public CacheGrain(ICacheGrainContext context, IOptions<CacheGrainOptions> options, ILogger<CacheGrain> logger, ICacheStorage storage, ISystemClock clock, IGrainIdentity identity, ICacheDirector director, ITimerRegistry timers)
         {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
             _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _storage = storage ?? throw new ArgumentNullException(nameof(storage));
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
             _identity = identity ?? throw new ArgumentNullException(nameof(identity));
@@ -315,7 +315,7 @@ namespace Outkeep.Grains
             catch (Exception ex)
             {
                 DeactivateOnIdle();
-                Log.Failed(_logger, _identity.PrimaryKeyString, ex);
+                Log.Failed(_context.Logger, _identity.PrimaryKeyString, ex);
                 throw;
             }
         }

--- a/src/Outkeep.Grains/CacheGrain.cs
+++ b/src/Outkeep.Grains/CacheGrain.cs
@@ -80,8 +80,6 @@ namespace Outkeep.Grains
 
         private void SetPulse(CachePulse pulse)
         {
-            if (pulse == _pulse) return;
-
             _pulse = pulse;
             _promise.TrySetResult(pulse);
             _promise = new TaskCompletionSource<CachePulse>();

--- a/src/Outkeep.Grains/CacheGrain.cs
+++ b/src/Outkeep.Grains/CacheGrain.cs
@@ -29,17 +29,6 @@ namespace Outkeep.Grains
 
         public override async Task OnActivateAsync()
         {
-            _context.TimerRegistry.RegisterTimer(this, _ =>
-            {
-                if (_entry != null && _entry.TryExpire(_context.Clock.UtcNow))
-                {
-                    _entry = null;
-                    SetPulse(CachePulse.None);
-                }
-
-                return Task.CompletedTask;
-            }, this, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
-
             // attempt to load from storage
             var item = await _context.Storage.ReadAsync(PrimaryKey).ConfigureAwait(true);
             if (!item.HasValue)

--- a/src/Outkeep.Grains/CacheGrain.cs
+++ b/src/Outkeep.Grains/CacheGrain.cs
@@ -239,10 +239,16 @@ namespace Outkeep.Grains
         /// <inheritdoc />
         public Task<CachePulse> PollAsync(Guid tag)
         {
-            // if there is no entry yet then return a promise
+            // if the user tag is different than the current tag then return the last pulse
+            if (tag != _pulse.Tag)
+            {
+                return Task.FromResult(_pulse);
+            }
+
+            // otherwise if there is no entry yet then return a promise until we have one
             if (_entry == null)
             {
-                return _promise.Task.WithDefaultOnTimeout(CachePulse.None, _context.Options.ReactivePollingTimeout);
+                return _promise.Task.WithDefaultOnTimeout(_pulse, _context.Options.ReactivePollingTimeout);
             }
 
             // if the current entry has expired then release it and return a clear pulse

--- a/src/Outkeep.Grains/CacheGrain.cs
+++ b/src/Outkeep.Grains/CacheGrain.cs
@@ -25,7 +25,7 @@ namespace Outkeep.Grains
         private readonly ICacheDirector _director;
         private readonly ITimerRegistry _timers;
 
-        public CacheGrain(ICacheGrainContext context, IOptions<CacheGrainOptions> options, ILogger<CacheGrain> logger, ICacheStorage storage, ISystemClock clock, IGrainIdentity identity, ICacheDirector director, ITimerRegistry timers)
+        public CacheGrain(ICacheGrainContext context, IOptions<CacheGrainOptions> options, ICacheStorage storage, ISystemClock clock, IGrainIdentity identity, ICacheDirector director, ITimerRegistry timers)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _options = options?.Value ?? throw new ArgumentNullException(nameof(options));

--- a/src/Outkeep.Grains/CacheGrain.cs
+++ b/src/Outkeep.Grains/CacheGrain.cs
@@ -2,7 +2,6 @@
 using Orleans;
 using Orleans.Concurrency;
 using Orleans.Core;
-using Orleans.Timers;
 using Outkeep.Core.Caching;
 using Outkeep.Core.Storage;
 using Outkeep.Grains.Properties;
@@ -17,13 +16,11 @@ namespace Outkeep.Grains
     {
         private readonly ICacheGrainContext _context;
         private readonly IGrainIdentity _identity;
-        private readonly ITimerRegistry _timers;
 
-        public CacheGrain(ICacheGrainContext context, IGrainIdentity identity, ITimerRegistry timers)
+        public CacheGrain(ICacheGrainContext context, IGrainIdentity identity)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _identity = identity ?? throw new ArgumentNullException(nameof(identity));
-            _timers = timers ?? throw new ArgumentNullException(nameof(timers));
         }
 
         private CachePulse _pulse = CachePulse.None;
@@ -33,7 +30,7 @@ namespace Outkeep.Grains
 
         public override async Task OnActivateAsync()
         {
-            _timers.RegisterTimer(this, _ =>
+            _context.TimerRegistry.RegisterTimer(this, _ =>
             {
                 if (_entry != null && _entry.TryExpire(_context.Clock.UtcNow))
                 {

--- a/src/Outkeep.Grains/CacheGrain.cs
+++ b/src/Outkeep.Grains/CacheGrain.cs
@@ -96,22 +96,11 @@ namespace Outkeep.Grains
         /// <inheritdoc />
         public ValueTask<CachePulse> GetAsync()
         {
-            // check if we have an entry at all
-            if (_entry == null) return new ValueTask<CachePulse>(CachePulse.None);
-
-            // check if the entry has expired
-            var now = _context.Clock.UtcNow;
-            if (_entry.TryExpire(now))
+            if (_entry != null)
             {
-                _entry = null;
-                SetPulse(new CachePulse(Guid.NewGuid(), new Immutable<byte[]?>(null)));
-                return new ValueTask<CachePulse>(_pulse);
+                _entry.UtcLastAccessed = _context.Clock.UtcNow;
             }
 
-            // update the accessed time to keep the entry from expiring
-            _entry.UtcLastAccessed = now;
-
-            // the entry has not yet expired so we can return the last pulse
             return new ValueTask<CachePulse>(_pulse);
         }
 

--- a/src/Outkeep.Grains/CacheGrain.cs
+++ b/src/Outkeep.Grains/CacheGrain.cs
@@ -17,14 +17,12 @@ namespace Outkeep.Grains
     {
         private readonly ICacheGrainContext _context;
         private readonly IGrainIdentity _identity;
-        private readonly ICacheDirector _director;
         private readonly ITimerRegistry _timers;
 
-        public CacheGrain(ICacheGrainContext context, IGrainIdentity identity, ICacheDirector director, ITimerRegistry timers)
+        public CacheGrain(ICacheGrainContext context, IGrainIdentity identity, ITimerRegistry timers)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _identity = identity ?? throw new ArgumentNullException(nameof(identity));
-            _director = director ?? throw new ArgumentNullException(nameof(director));
             _timers = timers ?? throw new ArgumentNullException(nameof(timers));
         }
 
@@ -55,7 +53,7 @@ namespace Outkeep.Grains
             }
 
             // attempt to claim space in the current box
-            _entry = _director
+            _entry = _context.Director
                 .CreateEntry(_identity.PrimaryKeyString, item.Value.Value.Length + IntPtr.Size)
                 .SetAbsoluteExpiration(item.Value.AbsoluteExpiration)
                 .SetSlidingExpiration(item.Value.SlidingExpiration)
@@ -168,7 +166,7 @@ namespace Outkeep.Grains
             }
 
             // claim space in the current box
-            _entry = _director
+            _entry = _context.Director
                 .CreateEntry(_identity.PrimaryKeyString, value.Value.Length + IntPtr.Size)
                 .SetAbsoluteExpiration(absoluteExpiration)
                 .SetSlidingExpiration(slidingExpiration)

--- a/src/Outkeep.Grains/CacheGrain.cs
+++ b/src/Outkeep.Grains/CacheGrain.cs
@@ -67,7 +67,7 @@ namespace Outkeep.Grains
             }
 
             // otherwise keep the content
-            SetPulse(new CachePulse(Guid.NewGuid(), item.Value.Value));
+            SetPulse(new CachePulse(Guid.NewGuid(), new Immutable<byte[]?>(item.Value.Value)));
         }
 
         public override Task OnDeactivateAsync()

--- a/src/Outkeep.Grains/CacheGrainContext.cs
+++ b/src/Outkeep.Grains/CacheGrainContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Outkeep.Core;
+using Outkeep.Core.Caching;
 using Outkeep.Core.Storage;
 using System;
 
@@ -11,12 +12,13 @@ namespace Outkeep.Grains
     /// </summary>
     internal class CacheGrainContext : ICacheGrainContext
     {
-        public CacheGrainContext(ILogger<CacheGrain> logger, IOptions<CacheGrainOptions> options, ICacheStorage storage, ISystemClock clock)
+        public CacheGrainContext(ILogger<CacheGrain> logger, IOptions<CacheGrainOptions> options, ICacheStorage storage, ISystemClock clock, ICacheDirector director)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             Storage = storage ?? throw new ArgumentNullException(nameof(storage));
             Clock = clock ?? throw new ArgumentNullException(nameof(clock));
+            Director = director ?? throw new ArgumentNullException(nameof(director));
         }
 
         public ILogger Logger { get; }
@@ -26,5 +28,7 @@ namespace Outkeep.Grains
         public ICacheStorage Storage { get; }
 
         public ISystemClock Clock { get; }
+
+        public ICacheDirector Director { get; }
     }
 }

--- a/src/Outkeep.Grains/CacheGrainContext.cs
+++ b/src/Outkeep.Grains/CacheGrainContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 
 namespace Outkeep.Grains
@@ -8,11 +9,14 @@ namespace Outkeep.Grains
     /// </summary>
     internal class CacheGrainContext : ICacheGrainContext
     {
-        public CacheGrainContext(ILogger<CacheGrain> logger)
+        public CacheGrainContext(ILogger<CacheGrain> logger, IOptions<CacheGrainOptions> options)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            Options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         }
 
         public ILogger Logger { get; }
+
+        public CacheGrainOptions Options { get; }
     }
 }

--- a/src/Outkeep.Grains/CacheGrainContext.cs
+++ b/src/Outkeep.Grains/CacheGrainContext.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+
+namespace Outkeep.Grains
+{
+    /// <summary>
+    /// This class groups together static dependencies for the cache grain in order to reduce memory footprint for each instance.
+    /// </summary>
+    internal class CacheGrainContext : ICacheGrainContext
+    {
+        public CacheGrainContext(ILogger<CacheGrain> logger)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public ILogger Logger { get; }
+    }
+}

--- a/src/Outkeep.Grains/CacheGrainContext.cs
+++ b/src/Outkeep.Grains/CacheGrainContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Orleans.Timers;
 using Outkeep.Core;
 using Outkeep.Core.Caching;
 using Outkeep.Core.Storage;
@@ -12,13 +13,14 @@ namespace Outkeep.Grains
     /// </summary>
     internal class CacheGrainContext : ICacheGrainContext
     {
-        public CacheGrainContext(ILogger<CacheGrain> logger, IOptions<CacheGrainOptions> options, ICacheStorage storage, ISystemClock clock, ICacheDirector director)
+        public CacheGrainContext(ILogger<CacheGrain> logger, IOptions<CacheGrainOptions> options, ICacheStorage storage, ISystemClock clock, ICacheDirector director, ITimerRegistry timerRegistry)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             Storage = storage ?? throw new ArgumentNullException(nameof(storage));
             Clock = clock ?? throw new ArgumentNullException(nameof(clock));
             Director = director ?? throw new ArgumentNullException(nameof(director));
+            TimerRegistry = timerRegistry ?? throw new ArgumentNullException(nameof(timerRegistry));
         }
 
         public ILogger Logger { get; }
@@ -30,5 +32,7 @@ namespace Outkeep.Grains
         public ISystemClock Clock { get; }
 
         public ICacheDirector Director { get; }
+
+        public ITimerRegistry TimerRegistry { get; }
     }
 }

--- a/src/Outkeep.Grains/CacheGrainContext.cs
+++ b/src/Outkeep.Grains/CacheGrainContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Outkeep.Core;
 using Outkeep.Core.Storage;
 using System;
 
@@ -10,11 +11,12 @@ namespace Outkeep.Grains
     /// </summary>
     internal class CacheGrainContext : ICacheGrainContext
     {
-        public CacheGrainContext(ILogger<CacheGrain> logger, IOptions<CacheGrainOptions> options, ICacheStorage storage)
+        public CacheGrainContext(ILogger<CacheGrain> logger, IOptions<CacheGrainOptions> options, ICacheStorage storage, ISystemClock clock)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             Storage = storage ?? throw new ArgumentNullException(nameof(storage));
+            Clock = clock ?? throw new ArgumentNullException(nameof(clock));
         }
 
         public ILogger Logger { get; }
@@ -22,5 +24,7 @@ namespace Outkeep.Grains
         public CacheGrainOptions Options { get; }
 
         public ICacheStorage Storage { get; }
+
+        public ISystemClock Clock { get; }
     }
 }

--- a/src/Outkeep.Grains/CacheGrainContext.cs
+++ b/src/Outkeep.Grains/CacheGrainContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Outkeep.Core.Storage;
 using System;
 
 namespace Outkeep.Grains
@@ -9,14 +10,17 @@ namespace Outkeep.Grains
     /// </summary>
     internal class CacheGrainContext : ICacheGrainContext
     {
-        public CacheGrainContext(ILogger<CacheGrain> logger, IOptions<CacheGrainOptions> options)
+        public CacheGrainContext(ILogger<CacheGrain> logger, IOptions<CacheGrainOptions> options, ICacheStorage storage)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             Options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+            Storage = storage ?? throw new ArgumentNullException(nameof(storage));
         }
 
         public ILogger Logger { get; }
 
         public CacheGrainOptions Options { get; }
+
+        public ICacheStorage Storage { get; }
     }
 }

--- a/src/Outkeep.Grains/CacheGrainContextServiceCollectionExtensions.cs
+++ b/src/Outkeep.Grains/CacheGrainContextServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Outkeep.Grains
+{
+    public static class CacheGrainContextServiceCollectionExtensions
+    {
+        public static IServiceCollection AddCacheGrainContext(this IServiceCollection services)
+        {
+            return services.AddSingleton<ICacheGrainContext, CacheGrainContext>();
+        }
+    }
+}

--- a/src/Outkeep.Grains/ICacheGrainContext.cs
+++ b/src/Outkeep.Grains/ICacheGrainContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Orleans.Timers;
 using Outkeep.Core;
 using Outkeep.Core.Caching;
 using Outkeep.Core.Storage;
@@ -12,5 +13,6 @@ namespace Outkeep.Grains
         ICacheStorage Storage { get; }
         ISystemClock Clock { get; }
         ICacheDirector Director { get; }
+        ITimerRegistry TimerRegistry { get; }
     }
 }

--- a/src/Outkeep.Grains/ICacheGrainContext.cs
+++ b/src/Outkeep.Grains/ICacheGrainContext.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Outkeep.Grains
+{
+    internal interface ICacheGrainContext
+    {
+        ILogger Logger { get; }
+    }
+}

--- a/src/Outkeep.Grains/ICacheGrainContext.cs
+++ b/src/Outkeep.Grains/ICacheGrainContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Outkeep.Core;
 using Outkeep.Core.Storage;
 
 namespace Outkeep.Grains
@@ -8,5 +9,6 @@ namespace Outkeep.Grains
         ILogger Logger { get; }
         CacheGrainOptions Options { get; }
         ICacheStorage Storage { get; }
+        ISystemClock Clock { get; }
     }
 }

--- a/src/Outkeep.Grains/ICacheGrainContext.cs
+++ b/src/Outkeep.Grains/ICacheGrainContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Outkeep.Core.Storage;
 
 namespace Outkeep.Grains
 {
@@ -6,5 +7,6 @@ namespace Outkeep.Grains
     {
         ILogger Logger { get; }
         CacheGrainOptions Options { get; }
+        ICacheStorage Storage { get; }
     }
 }

--- a/src/Outkeep.Grains/ICacheGrainContext.cs
+++ b/src/Outkeep.Grains/ICacheGrainContext.cs
@@ -5,5 +5,6 @@ namespace Outkeep.Grains
     internal interface ICacheGrainContext
     {
         ILogger Logger { get; }
+        CacheGrainOptions Options { get; }
     }
 }

--- a/src/Outkeep.Grains/ICacheGrainContext.cs
+++ b/src/Outkeep.Grains/ICacheGrainContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Outkeep.Core;
+using Outkeep.Core.Caching;
 using Outkeep.Core.Storage;
 
 namespace Outkeep.Grains
@@ -10,5 +11,6 @@ namespace Outkeep.Grains
         CacheGrainOptions Options { get; }
         ICacheStorage Storage { get; }
         ISystemClock Clock { get; }
+        ICacheDirector Director { get; }
     }
 }

--- a/src/Outkeep.Interfaces/CachePulse.cs
+++ b/src/Outkeep.Interfaces/CachePulse.cs
@@ -50,8 +50,23 @@ namespace Outkeep.Interfaces
         }
 
         /// <summary>
-        /// Returns a cache pulse with an empty tag and default (null) value.
+        /// Returns a cache pulse with an empty tag and null value.
         /// </summary>
         public static CachePulse None { get; } = new CachePulse(Guid.Empty, new Immutable<byte[]?>(null));
+
+        /// <summary>
+        /// Creates a new cache pulse with a random tag and null value.
+        /// </summary>
+        public static CachePulse RandomNull() => new CachePulse(Guid.NewGuid(), null);
+
+        /// <summary>
+        /// Creates a new cache pulse with a random tag and the provided value.
+        /// </summary>
+        public static CachePulse Random(byte[]? value) => new CachePulse(Guid.NewGuid(), value);
+
+        /// <summary>
+        /// Creates a new cache pulse with a random tag and the provided value.
+        /// </summary>
+        public static CachePulse Random(Immutable<byte[]?> value) => new CachePulse(Guid.NewGuid(), value);
     }
 }

--- a/test/Outkeep.Core.Tests/CacheDirectorTests.cs
+++ b/test/Outkeep.Core.Tests/CacheDirectorTests.cs
@@ -539,5 +539,21 @@ namespace Outkeep.Core.Tests
             // assert
             Assert.Throws<ArgumentNullException>(nameof(key), action);
         }
+
+        [Fact]
+        public void TryGetEntryHandlesNonExistingEntry()
+        {
+            // arrange
+            var options = new CacheOptions();
+            var director = new CacheDirector(Options.Create(options), NullLogger<CacheDirector>.Instance, NullClock.Default);
+            var key = Guid.NewGuid().ToString();
+
+            // act
+            var result = director.TryGetEntry(key, out var entry);
+
+            // assert
+            Assert.False(result);
+            Assert.Null(entry);
+        }
     }
 }

--- a/test/Outkeep.Core.Tests/CacheDirectorTests.cs
+++ b/test/Outkeep.Core.Tests/CacheDirectorTests.cs
@@ -508,5 +508,21 @@ namespace Outkeep.Core.Tests
             Assert.True(entry3.IsExpired);
             Assert.False(entry4.IsExpired);
         }
+
+        [Fact]
+        public void CreateEntryThrowsOnSizeTooLarge()
+        {
+            // arrange
+            var options = new CacheOptions { Capacity = 1000 };
+            var director = new CacheDirector(Options.Create(options), NullLogger<CacheDirector>.Instance, NullClock.Default);
+            var key = Guid.NewGuid().ToString();
+            var size = options.Capacity + 1;
+
+            // act
+            void action() => director.CreateEntry(key, 1001);
+
+            // assert
+            Assert.Throws<ArgumentOutOfRangeException>(nameof(size), action);
+        }
     }
 }

--- a/test/Outkeep.Core.Tests/CacheDirectorTests.cs
+++ b/test/Outkeep.Core.Tests/CacheDirectorTests.cs
@@ -524,5 +524,20 @@ namespace Outkeep.Core.Tests
             // assert
             Assert.Throws<ArgumentOutOfRangeException>(nameof(size), action);
         }
+
+        [Fact]
+        public void TryGetEntryThrowsOnNullKey()
+        {
+            // arrange
+            var options = new CacheOptions();
+            var director = new CacheDirector(Options.Create(options), NullLogger<CacheDirector>.Instance, NullClock.Default);
+            string? key = null;
+
+            // act
+            void action() => director.TryGetEntry(null!, out _);
+
+            // assert
+            Assert.Throws<ArgumentNullException>(nameof(key), action);
+        }
     }
 }

--- a/test/Outkeep.Core.Tests/CacheDirectorTests.cs
+++ b/test/Outkeep.Core.Tests/CacheDirectorTests.cs
@@ -585,5 +585,33 @@ namespace Outkeep.Core.Tests
             Assert.False(entry.IsExpired);
             Assert.True(previous.IsExpired);
         }
+
+        [Fact]
+        public void ExpiresEntryOnOverflow()
+        {
+            // arrange
+            var options = new CacheOptions { Capacity = long.MaxValue };
+            var director = new CacheDirector(Options.Create(options), NullLogger<CacheDirector>.Instance, NullClock.Default);
+            var key = Guid.NewGuid().ToString();
+
+            // act
+            var filler = director
+                .CreateEntry(key, long.MaxValue - 100)
+                .Commit();
+
+            // assert
+            Assert.NotNull(filler);
+            Assert.False(filler.IsExpired);
+
+            // act
+            var entry = director
+                .CreateEntry(key, 1000)
+                .Commit();
+
+            // assert
+            Assert.NotNull(entry);
+            Assert.True(entry.IsExpired);
+            Assert.True(filler.IsExpired);
+        }
     }
 }

--- a/test/Outkeep.Core.Tests/CacheEntryExtensionsTests.cs
+++ b/test/Outkeep.Core.Tests/CacheEntryExtensionsTests.cs
@@ -103,10 +103,12 @@ namespace Outkeep.Core.Tests
 
             // act
             var completed = false;
-            entry.ContinueWithOnEvicted(t => completed = true, CancellationToken.None);
+            var chain = entry.ContinueWithOnEvicted(t => completed = true, out var continuation, CancellationToken.None);
 
             // assert
-            await Task.Delay(200).ConfigureAwait(false);
+            Assert.Same(entry, chain);
+            Assert.NotNull(continuation);
+            await continuation.ConfigureAwait(false);
             Assert.True(completed);
         }
 

--- a/test/Outkeep.Core.Tests/CacheEntryExtensionsTests.cs
+++ b/test/Outkeep.Core.Tests/CacheEntryExtensionsTests.cs
@@ -106,7 +106,7 @@ namespace Outkeep.Core.Tests
             entry.ContinueWithOnEvicted(t => completed = true, CancellationToken.None);
 
             // assert
-            await Task.Delay(100).ConfigureAwait(false);
+            await Task.Delay(200).ConfigureAwait(false);
             Assert.True(completed);
         }
 

--- a/test/Outkeep.Core.Tests/MemoryCacheStorageOutkeepServerBuilderExtensionsTests.cs
+++ b/test/Outkeep.Core.Tests/MemoryCacheStorageOutkeepServerBuilderExtensionsTests.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Outkeep.Core.Storage;
+using Outkeep.Core.Tests.Fakes;
+using System;
+using Xunit;
+
+namespace Outkeep.Core.Tests
+{
+    public class MemoryCacheStorageOutkeepServerBuilderExtensionsTests
+    {
+        [Fact]
+        public void AddMemoryCacheStorageThrowsOnNullBuilder()
+        {
+            // arrange
+            IOutkeepServerBuilder builder = null!;
+
+            // act
+            void action() => builder.AddMemoryCacheStorage();
+
+            // act and assert
+            Assert.Throws<ArgumentNullException>(nameof(builder), action);
+        }
+
+        [Fact]
+        public void AddMemoryCacheStorageAddsServices()
+        {
+            // arrange
+            var builder = new FakeOutkeepServerBuilder();
+
+            // act
+            var result = builder.AddMemoryCacheStorage();
+            var service = builder.BuildServiceProvider(null!, null!).GetService<ICacheStorage>();
+
+            // assert
+            Assert.Same(builder, result);
+            Assert.IsType<MemoryCacheStorage>(service);
+        }
+    }
+}

--- a/test/Outkeep.Core.Tests/NullCacheStorageOutkeepServerBuilderExtensionsTests.cs
+++ b/test/Outkeep.Core.Tests/NullCacheStorageOutkeepServerBuilderExtensionsTests.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Outkeep.Core.Storage;
+using Outkeep.Core.Tests.Fakes;
+using System;
+using Xunit;
+
+namespace Outkeep.Core.Tests
+{
+    public class NullCacheStorageOutkeepServerBuilderExtensionsTests
+    {
+        [Fact]
+        public void AddNullCacheStorageThrowsOnNullBuilder()
+        {
+            // arrange
+            IOutkeepServerBuilder builder = null!;
+
+            // act
+            void action() => builder.AddNullCacheStorage();
+
+            // act and assert
+            Assert.Throws<ArgumentNullException>(nameof(builder), action);
+        }
+
+        [Fact]
+        public void AddNullCacheStorageAddsServices()
+        {
+            // arrange
+            var builder = new FakeOutkeepServerBuilder();
+
+            // act
+            var result = builder.AddNullCacheStorage();
+            var service = builder.BuildServiceProvider(null!, null!).GetService<ICacheStorage>();
+
+            // assert
+            Assert.Same(builder, result);
+            Assert.IsType<NullCacheStorage>(service);
+        }
+    }
+}

--- a/test/Outkeep.Core.Tests/Outkeep.Core.Tests.csproj
+++ b/test/Outkeep.Core.Tests/Outkeep.Core.Tests.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="MemoryCacheStorageOutkeepServerBuilderExtensionsTests.cs~RF39b68eae.TMP" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -316,6 +316,18 @@ namespace Outkeep.Grains.Tests
             Assert.NotEqual(Guid.Empty, result3.Tag);
             Assert.NotEqual(result2.Tag, result3.Tag);
             Assert.Equal(value3, result3.Value.Value);
+
+            // arrange - get the underlying entry
+            var okay = _fixture.PrimarySiloServiceProvider.GetRequiredService<ICacheDirector>().TryGetEntry(key, out var entry);
+            Assert.True(okay);
+            Assert.NotNull(entry);
+            var lastAccessed = entry!.UtcLastAccessed;
+
+            // act - access the value again to update the accessed timestamp
+            await grain.PollAsync(Guid.NewGuid()).ConfigureAwait(false);
+
+            // assert
+            Assert.True(entry.UtcLastAccessed > lastAccessed);
         }
     }
 }

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -248,5 +248,21 @@ namespace Outkeep.Grains.Tests
             // assert
             Assert.True(entry?.UtcLastAccessed > accessed);
         }
+
+        [Fact]
+        public async Task PollAsyncReturnsEmptyPulseOnRandomTagWithNoEntry()
+        {
+            // arrange
+            var key = Guid.NewGuid().ToString();
+            var tag = Guid.NewGuid();
+            var grain = _fixture.Cluster.GrainFactory.GetCacheGrain(key);
+
+            // act
+            var result = await grain.PollAsync(tag).ConfigureAwait(false);
+
+            // assert
+            Assert.Null(result.Value.Value);
+            Assert.Equal(Guid.Empty, result.Tag);
+        }
     }
 }

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -207,5 +207,23 @@ namespace Outkeep.Grains.Tests
             // assert
             Assert.True(true);
         }
+
+        [Fact]
+        public async Task SettingNullClearsStorage()
+        {
+            // arrange
+            var key = Guid.NewGuid().ToString();
+            var grain = _fixture.Cluster.GrainFactory.GetCacheGrain(key);
+            var storage = _fixture.PrimarySiloServiceProvider.GetService<ICacheStorage>();
+
+            await storage.WriteAsync(key, new CacheItem(Guid.NewGuid().ToByteArray(), DateTimeOffset.UtcNow.AddDays(1), TimeSpan.MaxValue)).ConfigureAwait(false);
+
+            // act
+            await grain.SetAsync(new Immutable<byte[]?>(null), DateTimeOffset.UtcNow.AddMinutes(1), TimeSpan.MaxValue).ConfigureAwait(false);
+
+            // assert
+            var result = await storage.ReadAsync(key).ConfigureAwait(false);
+            Assert.False(result.HasValue);
+        }
     }
 }

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Moq;
+﻿using Moq;
 using Orleans.Concurrency;
 using Orleans.Core;
 using Orleans.Timers;
@@ -19,14 +18,13 @@ namespace Outkeep.Grains.Tests
         {
             // arrange
             var key = "SomeKey";
-            var options = Options.Create(new CacheGrainOptions { });
             var storage = Mock.Of<ICacheStorage>(x => x.ReadAsync(key, default) == Task.FromResult<CacheItem?>(null));
             var clock = Mock.Of<ISystemClock>();
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
             var director = Mock.Of<ICacheDirector>();
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>();
-            var grain = new CacheGrain(context, options, storage, clock, identity, director, timers);
+            var grain = new CacheGrain(context, storage, clock, identity, director, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -42,7 +40,6 @@ namespace Outkeep.Grains.Tests
         {
             // arrange
             var key = "SomeKey";
-            var options = Options.Create(new CacheGrainOptions { });
             var value = Guid.NewGuid().ToByteArray();
             var storage = Mock.Of<ICacheStorage>(x => x.ReadAsync(key, default) == Task.FromResult<CacheItem?>(new CacheItem(value, null, null)));
             var clock = Mock.Of<ISystemClock>();
@@ -55,7 +52,7 @@ namespace Outkeep.Grains.Tests
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>();
 
-            var grain = new CacheGrain(context, options, storage, clock, identity, director, timers);
+            var grain = new CacheGrain(context, storage, clock, identity, director, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -86,7 +83,6 @@ namespace Outkeep.Grains.Tests
 
             var grain = new CacheGrain(
                 context,
-                Options.Create(new CacheGrainOptions { }),
                 storage,
                 Mock.Of<ISystemClock>(),
                 Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key),
@@ -116,7 +112,6 @@ namespace Outkeep.Grains.Tests
             // arrange
             var key = "SomeKey";
             var value = Guid.NewGuid().ToByteArray();
-            var options = Options.Create(new CacheGrainOptions { });
             var storage = new MemoryCacheStorage();
             var clock = Mock.Of<ISystemClock>();
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
@@ -128,7 +123,7 @@ namespace Outkeep.Grains.Tests
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>();
 
-            var grain = new CacheGrain(context, options, storage, clock, identity, director, timers);
+            var grain = new CacheGrain(context, storage, clock, identity, director, timers);
 
             // act - set the value
             var absolute = DateTimeOffset.UtcNow;

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -1,7 +1,7 @@
-﻿using Moq;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Orleans.Concurrency;
-using Outkeep.Core.Caching;
 using Outkeep.Core.Storage;
+using Outkeep.Interfaces;
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -22,131 +22,114 @@ namespace Outkeep.Grains.Tests
         public async Task GetReturnsNullValueFromStorage()
         {
             // arrange
-            var key = "SomeKey";
-            var storage = Mock.Of<ICacheStorage>(x => x.ReadAsync(key, default) == Task.FromResult<CacheItem?>(null));
-            var context = Mock.Of<ICacheGrainContext>(x =>
-                x.Storage == storage);
-            var grain = new CacheGrain(context);
-            await grain.OnActivateAsync().ConfigureAwait(false);
+            var key = Guid.NewGuid().ToString();
 
             // act
-            var result = await grain.GetAsync().ConfigureAwait(false);
+            var result = await _fixture.Cluster.GrainFactory
+                .GetGrain<ICacheGrain>(key)
+                .GetAsync();
 
             // assert
             Assert.Null(result.Value.Value);
-            Mock.Get(storage).VerifyAll();
         }
 
         [Fact]
         public async Task GetReturnsCorrectValueFromStorage()
         {
             // arrange
-            var key = "SomeKey";
+            var key = Guid.NewGuid().ToString();
             var value = Guid.NewGuid().ToByteArray();
-            var storage = Mock.Of<ICacheStorage>(x => x.ReadAsync(key, default) == Task.FromResult<CacheItem?>(new CacheItem(value, null, null)));
 
-            var entry = Mock.Of<ICacheEntry>();
-            Mock.Get(entry).Setup(x => x.Commit()).Returns(entry);
-
-            var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
-            var context = Mock.Of<ICacheGrainContext>(x =>
-                x.Storage == storage &&
-                x.Clock.UtcNow == DateTimeOffset.UtcNow &&
-                x.Director == director);
-
-            var grain = new CacheGrain(context);
-            await grain.OnActivateAsync().ConfigureAwait(false);
+            await _fixture.PrimarySiloServiceProvider.GetRequiredService<ICacheStorage>()
+                .WriteAsync(key, new CacheItem(value, null, null))
+                .ConfigureAwait(false);
 
             // act
-            var result = await grain.GetAsync().ConfigureAwait(false);
+            var result = await _fixture.Cluster.GrainFactory
+                .GetGrain<ICacheGrain>(key)
+                .GetAsync();
 
             // assert
             Assert.NotNull(result.Value.Value);
-            Assert.Same(value, result.Value.Value);
-            Mock.Get(storage).VerifyAll();
+            Assert.Equal(value, result.Value.Value);
         }
 
         [Fact]
         public async Task GetReturnsCorrectValueFromMemory()
         {
             // arrange
-            var key = "SomeKey";
+            var key = Guid.NewGuid().ToString();
             var value = Guid.NewGuid().ToByteArray();
 
-            var storage = Mock.Of<ICacheStorage>();
-            Mock.Get(storage).Setup(x => x.ReadAsync(key, default)).Returns(Task.FromResult<CacheItem?>(new CacheItem(value, null, null)));
-
-            var entry = Mock.Of<ICacheEntry>();
-            Mock.Get(entry).Setup(x => x.Commit()).Returns(entry);
-
-            var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
-            var context = Mock.Of<ICacheGrainContext>(x =>
-                x.Storage == storage &&
-                x.Clock.UtcNow == DateTimeOffset.UtcNow &&
-                x.Director == director);
-
-            var grain = new CacheGrain(context);
+            await _fixture.PrimarySiloServiceProvider.GetRequiredService<ICacheStorage>()
+                .WriteAsync(key, new CacheItem(value, null, null))
+                .ConfigureAwait(false);
 
             // act - this will load the value from storage
-            await grain.OnActivateAsync().ConfigureAwait(false);
-            var result = await grain.GetAsync().ConfigureAwait(false);
+            var result = await _fixture.Cluster.GrainFactory
+                .GetGrain<ICacheGrain>(key)
+                .GetAsync();
 
             // assert
-            Assert.Same(value, result.Value.Value);
+            Assert.Equal(value, result.Value.Value);
 
             // arrange - clear storage
-            Mock.Get(storage).Setup(x => x.ReadAsync(key, default)).Returns(Task.FromResult<CacheItem?>(null));
+            await _fixture.PrimarySiloServiceProvider.GetRequiredService<ICacheStorage>()
+                .ClearAsync(key)
+                .ConfigureAwait(false);
 
             // act - this must reuse the value in memory
-            result = await grain.GetAsync().ConfigureAwait(false);
+            result = await _fixture.Cluster.GrainFactory
+                .GetGrain<ICacheGrain>(key)
+                .GetAsync();
 
             // assert
-            Assert.Same(value, result.Value.Value);
+            Assert.Equal(value, result.Value.Value);
         }
 
         [Fact]
         public async Task RemoveClearsValueFromMemoryAndStorage()
         {
             // arrange
-            var key = "SomeKey";
+            var key = Guid.NewGuid().ToString();
             var value = Guid.NewGuid().ToByteArray();
-            var storage = new MemoryCacheStorage();
-
-            var entry = Mock.Of<ICacheEntry>();
-            Mock.Get(entry).Setup(x => x.Commit()).Returns(entry);
-            var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
-
-            var context = Mock.Of<ICacheGrainContext>(x =>
-                x.Storage == storage &&
-                x.Clock.UtcNow == DateTimeOffset.UtcNow &&
-                x.Director == director);
-
-            var grain = new CacheGrain(context);
+            var grain = _fixture.Cluster.GrainFactory.GetGrain<ICacheGrain>(key);
 
             // act - set the value
-            var absolute = DateTimeOffset.UtcNow;
-            var sliding = TimeSpan.MaxValue;
-            await grain.OnActivateAsync().ConfigureAwait(false);
+            var absolute = DateTimeOffset.UtcNow.AddHours(1);
+            var sliding = TimeSpan.FromMinutes(1);
             await grain.SetAsync(new Immutable<byte[]?>(value), absolute, sliding).ConfigureAwait(false);
 
             // assert value is set in storage
-            var stored = await storage.ReadAsync(key).ConfigureAwait(false);
-            Assert.Same(value, stored.Value.Value);
+            var stored = await _fixture.PrimarySiloServiceProvider
+                .GetRequiredService<ICacheStorage>()
+                .ReadAsync(key)
+                .ConfigureAwait(false);
+
+            Assert.Equal(value, stored.Value.Value);
             Assert.Equal(absolute, stored.Value.AbsoluteExpiration);
             Assert.Equal(sliding, stored.Value.SlidingExpiration);
 
             // assert value is set in memory
             var result = await grain.GetAsync().ConfigureAwait(false);
-            Assert.Same(value, result.Value.Value);
+            Assert.Equal(value, result.Value.Value);
 
             // act - clear the value
             await grain.RemoveAsync().ConfigureAwait(false);
 
             // assert value is cleared from storage
-            Assert.False((await storage.ReadAsync(key).ConfigureAwait(false)).HasValue);
+            var cleared = await _fixture.PrimarySiloServiceProvider
+                .GetRequiredService<ICacheStorage>()
+                .ReadAsync(key)
+                .ConfigureAwait(false);
+
+            Assert.False(cleared.HasValue);
 
             // arrange - add dummy value to storage
-            await storage.WriteAsync(key, new CacheItem(value, absolute, sliding)).ConfigureAwait(false);
+            await _fixture.PrimarySiloServiceProvider
+                .GetRequiredService<ICacheStorage>()
+                .WriteAsync(key, new CacheItem(value, absolute, sliding))
+                .ConfigureAwait(false);
 
             // assert value is cleared from memory and not reloaded
             result = await grain.GetAsync().ConfigureAwait(false);

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -23,8 +23,9 @@ namespace Outkeep.Grains.Tests
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
             var director = Mock.Of<ICacheDirector>();
             var timers = Mock.Of<ITimerRegistry>();
-            var context = Mock.Of<ICacheGrainContext>();
-            var grain = new CacheGrain(context, storage, clock, identity, director, timers);
+            var context = Mock.Of<ICacheGrainContext>(x =>
+                x.Storage == storage);
+            var grain = new CacheGrain(context, clock, identity, director, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -50,9 +51,10 @@ namespace Outkeep.Grains.Tests
 
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
             var timers = Mock.Of<ITimerRegistry>();
-            var context = Mock.Of<ICacheGrainContext>();
+            var context = Mock.Of<ICacheGrainContext>(x =>
+                x.Storage == storage);
 
-            var grain = new CacheGrain(context, storage, clock, identity, director, timers);
+            var grain = new CacheGrain(context, clock, identity, director, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -79,11 +81,11 @@ namespace Outkeep.Grains.Tests
 
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
             var timers = Mock.Of<ITimerRegistry>();
-            var context = Mock.Of<ICacheGrainContext>();
+            var context = Mock.Of<ICacheGrainContext>(x =>
+                x.Storage == storage);
 
             var grain = new CacheGrain(
                 context,
-                storage,
                 Mock.Of<ISystemClock>(),
                 Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key),
                 director,
@@ -121,9 +123,10 @@ namespace Outkeep.Grains.Tests
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
 
             var timers = Mock.Of<ITimerRegistry>();
-            var context = Mock.Of<ICacheGrainContext>();
+            var context = Mock.Of<ICacheGrainContext>(x =>
+                x.Storage == storage);
 
-            var grain = new CacheGrain(context, storage, clock, identity, director, timers);
+            var grain = new CacheGrain(context, clock, identity, director, timers);
 
             // act - set the value
             var absolute = DateTimeOffset.UtcNow;

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -2,7 +2,6 @@
 using Orleans.Concurrency;
 using Orleans.Core;
 using Orleans.Timers;
-using Outkeep.Core;
 using Outkeep.Core.Caching;
 using Outkeep.Core.Storage;
 using System;
@@ -19,13 +18,12 @@ namespace Outkeep.Grains.Tests
             // arrange
             var key = "SomeKey";
             var storage = Mock.Of<ICacheStorage>(x => x.ReadAsync(key, default) == Task.FromResult<CacheItem?>(null));
-            var clock = Mock.Of<ISystemClock>();
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
             var director = Mock.Of<ICacheDirector>();
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
                 x.Storage == storage);
-            var grain = new CacheGrain(context, clock, identity, director, timers);
+            var grain = new CacheGrain(context, identity, director, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -43,7 +41,6 @@ namespace Outkeep.Grains.Tests
             var key = "SomeKey";
             var value = Guid.NewGuid().ToByteArray();
             var storage = Mock.Of<ICacheStorage>(x => x.ReadAsync(key, default) == Task.FromResult<CacheItem?>(new CacheItem(value, null, null)));
-            var clock = Mock.Of<ISystemClock>();
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
 
             var entry = Mock.Of<ICacheEntry>();
@@ -52,9 +49,10 @@ namespace Outkeep.Grains.Tests
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
-                x.Storage == storage);
+                x.Storage == storage &&
+                x.Clock.UtcNow == DateTimeOffset.UtcNow);
 
-            var grain = new CacheGrain(context, clock, identity, director, timers);
+            var grain = new CacheGrain(context, identity, director, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -82,11 +80,11 @@ namespace Outkeep.Grains.Tests
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
-                x.Storage == storage);
+                x.Storage == storage &&
+                x.Clock.UtcNow == DateTimeOffset.UtcNow);
 
             var grain = new CacheGrain(
                 context,
-                Mock.Of<ISystemClock>(),
                 Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key),
                 director,
                 timers);
@@ -115,7 +113,6 @@ namespace Outkeep.Grains.Tests
             var key = "SomeKey";
             var value = Guid.NewGuid().ToByteArray();
             var storage = new MemoryCacheStorage();
-            var clock = Mock.Of<ISystemClock>();
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
 
             var entry = Mock.Of<ICacheEntry>();
@@ -124,9 +121,10 @@ namespace Outkeep.Grains.Tests
 
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
-                x.Storage == storage);
+                x.Storage == storage &&
+                x.Clock.UtcNow == DateTimeOffset.UtcNow);
 
-            var grain = new CacheGrain(context, clock, identity, director, timers);
+            var grain = new CacheGrain(context, identity, director, timers);
 
             // act - set the value
             var absolute = DateTimeOffset.UtcNow;

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -19,11 +19,10 @@ namespace Outkeep.Grains.Tests
             var key = "SomeKey";
             var storage = Mock.Of<ICacheStorage>(x => x.ReadAsync(key, default) == Task.FromResult<CacheItem?>(null));
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
-            var director = Mock.Of<ICacheDirector>();
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
                 x.Storage == storage);
-            var grain = new CacheGrain(context, identity, director, timers);
+            var grain = new CacheGrain(context, identity, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -50,9 +49,10 @@ namespace Outkeep.Grains.Tests
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
                 x.Storage == storage &&
-                x.Clock.UtcNow == DateTimeOffset.UtcNow);
+                x.Clock.UtcNow == DateTimeOffset.UtcNow &&
+                x.Director == director);
 
-            var grain = new CacheGrain(context, identity, director, timers);
+            var grain = new CacheGrain(context, identity, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -81,12 +81,12 @@ namespace Outkeep.Grains.Tests
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
                 x.Storage == storage &&
-                x.Clock.UtcNow == DateTimeOffset.UtcNow);
+                x.Clock.UtcNow == DateTimeOffset.UtcNow &&
+                x.Director == director);
 
             var grain = new CacheGrain(
                 context,
                 Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key),
-                director,
                 timers);
 
             // act - this will load the value from storage
@@ -122,9 +122,10 @@ namespace Outkeep.Grains.Tests
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
                 x.Storage == storage &&
-                x.Clock.UtcNow == DateTimeOffset.UtcNow);
+                x.Clock.UtcNow == DateTimeOffset.UtcNow &&
+                x.Director == director);
 
-            var grain = new CacheGrain(context, identity, director, timers);
+            var grain = new CacheGrain(context, identity, timers);
 
             // act - set the value
             var absolute = DateTimeOffset.UtcNow;

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -1,7 +1,6 @@
 ﻿using Moq;
 using Orleans.Concurrency;
 using Orleans.Core;
-using Orleans.Timers;
 using Outkeep.Core.Caching;
 using Outkeep.Core.Storage;
 using System;
@@ -19,10 +18,9 @@ namespace Outkeep.Grains.Tests
             var key = "SomeKey";
             var storage = Mock.Of<ICacheStorage>(x => x.ReadAsync(key, default) == Task.FromResult<CacheItem?>(null));
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
-            var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
                 x.Storage == storage);
-            var grain = new CacheGrain(context, identity, timers);
+            var grain = new CacheGrain(context, identity);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -46,13 +44,12 @@ namespace Outkeep.Grains.Tests
             Mock.Get(entry).Setup(x => x.Commit()).Returns(entry);
 
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
-            var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
                 x.Storage == storage &&
                 x.Clock.UtcNow == DateTimeOffset.UtcNow &&
                 x.Director == director);
 
-            var grain = new CacheGrain(context, identity, timers);
+            var grain = new CacheGrain(context, identity);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -78,7 +75,6 @@ namespace Outkeep.Grains.Tests
             Mock.Get(entry).Setup(x => x.Commit()).Returns(entry);
 
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
-            var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
                 x.Storage == storage &&
                 x.Clock.UtcNow == DateTimeOffset.UtcNow &&
@@ -86,8 +82,7 @@ namespace Outkeep.Grains.Tests
 
             var grain = new CacheGrain(
                 context,
-                Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key),
-                timers);
+                Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key));
 
             // act - this will load the value from storage
             await grain.OnActivateAsync().ConfigureAwait(false);
@@ -119,13 +114,12 @@ namespace Outkeep.Grains.Tests
             Mock.Get(entry).Setup(x => x.Commit()).Returns(entry);
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
 
-            var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>(x =>
                 x.Storage == storage &&
                 x.Clock.UtcNow == DateTimeOffset.UtcNow &&
                 x.Director == director);
 
-            var grain = new CacheGrain(context, identity, timers);
+            var grain = new CacheGrain(context, identity);
 
             // act - set the value
             var absolute = DateTimeOffset.UtcNow;

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -28,7 +28,8 @@ namespace Outkeep.Grains.Tests
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
             var director = Mock.Of<ICacheDirector>();
             var timers = Mock.Of<ITimerRegistry>();
-            var grain = new CacheGrain(options, logger, storage, clock, identity, director, timers);
+            var context = Mock.Of<ICacheGrainContext>();
+            var grain = new CacheGrain(context, options, logger, storage, clock, identity, director, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -56,8 +57,9 @@ namespace Outkeep.Grains.Tests
 
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
             var timers = Mock.Of<ITimerRegistry>();
+            var context = Mock.Of<ICacheGrainContext>();
 
-            var grain = new CacheGrain(options, logger, storage, clock, identity, director, timers);
+            var grain = new CacheGrain(context, options, logger, storage, clock, identity, director, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -84,8 +86,10 @@ namespace Outkeep.Grains.Tests
 
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
             var timers = Mock.Of<ITimerRegistry>();
+            var context = Mock.Of<ICacheGrainContext>();
 
             var grain = new CacheGrain(
+                context,
                 Options.Create(new CacheGrainOptions { }),
                 new NullLogger<CacheGrain>(),
                 storage,
@@ -128,7 +132,9 @@ namespace Outkeep.Grains.Tests
             var director = Mock.Of<ICacheDirector>(x => x.CreateEntry(key, value.Length + IntPtr.Size) == entry);
 
             var timers = Mock.Of<ITimerRegistry>();
-            var grain = new CacheGrain(options, logger, storage, clock, identity, director, timers);
+            var context = Mock.Of<ICacheGrainContext>();
+
+            var grain = new CacheGrain(context, options, logger, storage, clock, identity, director, timers);
 
             // act - set the value
             var absolute = DateTimeOffset.UtcNow;

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using Moq;
 using Orleans.Concurrency;
 using Orleans.Core;
@@ -22,14 +20,13 @@ namespace Outkeep.Grains.Tests
             // arrange
             var key = "SomeKey";
             var options = Options.Create(new CacheGrainOptions { });
-            var logger = Mock.Of<ILogger<CacheGrain>>();
             var storage = Mock.Of<ICacheStorage>(x => x.ReadAsync(key, default) == Task.FromResult<CacheItem?>(null));
             var clock = Mock.Of<ISystemClock>();
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
             var director = Mock.Of<ICacheDirector>();
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>();
-            var grain = new CacheGrain(context, options, logger, storage, clock, identity, director, timers);
+            var grain = new CacheGrain(context, options, storage, clock, identity, director, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -46,7 +43,6 @@ namespace Outkeep.Grains.Tests
             // arrange
             var key = "SomeKey";
             var options = Options.Create(new CacheGrainOptions { });
-            var logger = Mock.Of<ILogger<CacheGrain>>();
             var value = Guid.NewGuid().ToByteArray();
             var storage = Mock.Of<ICacheStorage>(x => x.ReadAsync(key, default) == Task.FromResult<CacheItem?>(new CacheItem(value, null, null)));
             var clock = Mock.Of<ISystemClock>();
@@ -59,7 +55,7 @@ namespace Outkeep.Grains.Tests
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>();
 
-            var grain = new CacheGrain(context, options, logger, storage, clock, identity, director, timers);
+            var grain = new CacheGrain(context, options, storage, clock, identity, director, timers);
             await grain.OnActivateAsync().ConfigureAwait(false);
 
             // act
@@ -91,7 +87,6 @@ namespace Outkeep.Grains.Tests
             var grain = new CacheGrain(
                 context,
                 Options.Create(new CacheGrainOptions { }),
-                new NullLogger<CacheGrain>(),
                 storage,
                 Mock.Of<ISystemClock>(),
                 Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key),
@@ -122,7 +117,6 @@ namespace Outkeep.Grains.Tests
             var key = "SomeKey";
             var value = Guid.NewGuid().ToByteArray();
             var options = Options.Create(new CacheGrainOptions { });
-            var logger = new NullLogger<CacheGrain>();
             var storage = new MemoryCacheStorage();
             var clock = Mock.Of<ISystemClock>();
             var identity = Mock.Of<IGrainIdentity>(x => x.PrimaryKeyString == key);
@@ -134,7 +128,7 @@ namespace Outkeep.Grains.Tests
             var timers = Mock.Of<ITimerRegistry>();
             var context = Mock.Of<ICacheGrainContext>();
 
-            var grain = new CacheGrain(context, options, logger, storage, clock, identity, director, timers);
+            var grain = new CacheGrain(context, options, storage, clock, identity, director, timers);
 
             // act - set the value
             var absolute = DateTimeOffset.UtcNow;

--- a/test/Outkeep.Grains.Tests/CacheGrainTests.cs
+++ b/test/Outkeep.Grains.Tests/CacheGrainTests.cs
@@ -193,5 +193,19 @@ namespace Outkeep.Grains.Tests
             Assert.Null(result.Value.Value);
             Assert.Equal(Guid.Empty, result.Tag);
         }
+
+        [Fact]
+        public async Task RemoveNoopsIfEmpty()
+        {
+            // arrange
+            var key = Guid.NewGuid().ToString();
+            var grain = _fixture.Cluster.GrainFactory.GetCacheGrain(key);
+
+            // act
+            await grain.RemoveAsync().ConfigureAwait(false);
+
+            // assert
+            Assert.True(true);
+        }
     }
 }

--- a/test/Outkeep.Grains.Tests/ClusterFixture.cs
+++ b/test/Outkeep.Grains.Tests/ClusterFixture.cs
@@ -59,7 +59,11 @@ namespace Outkeep.Grains.Tests
                                 options.Capacity = 1000;
                             })
                             .AddSystemClock()
-                            .AddCacheGrainContext();
+                            .AddCacheGrainContext()
+                            .Configure<CacheGrainOptions>(options =>
+                            {
+                                options.ReactivePollingTimeout = TimeSpan.FromSeconds(5);
+                            });
                     })
                     .AddCacheDirectorGrainService()
                     .UseServiceProviderFactory(services =>


### PR DESCRIPTION
This reduces the memory footprint of the cache grain. Closes #7 .