### PR TITLE
Move TcpHelper to Core

### DIFF
--- a/src/Outkeep.Core/Properties/Resources.Designer.cs
+++ b/src/Outkeep.Core/Properties/Resources.Designer.cs
@@ -205,6 +205,15 @@ namespace Outkeep.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not open a dynamic port for exclusive use.
+        /// </summary>
+        internal static string Exception_CouldNotOpenADynamicPortForExclusiveUse {
+            get {
+                return ResourceManager.GetString("Exception_CouldNotOpenADynamicPortForExclusiveUse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to clear cache file {0} for key {1}.
         /// </summary>
         internal static string Exception_FailedToClearCacheFile_X_ForKey_X {
@@ -256,6 +265,24 @@ namespace Outkeep.Core.Properties {
             get {
                 return ResourceManager.GetString("Exception_Property_X_WithValue_X_MustBeGreaterThanOrEqualToProperty_X_WithValue_X" +
                         "", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to There are no free ports within the input range.
+        /// </summary>
+        internal static string Exception_ThereAreNoFreePortsWithinTheInputRange {
+            get {
+                return ResourceManager.GetString("Exception_ThereAreNoFreePortsWithinTheInputRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unexpected endpoint type.
+        /// </summary>
+        internal static string Exception_UnexpectedEndpointType {
+            get {
+                return ResourceManager.GetString("Exception_UnexpectedEndpointType", resourceCulture);
             }
         }
         

--- a/src/Outkeep.Core/Properties/Resources.resx
+++ b/src/Outkeep.Core/Properties/Resources.resx
@@ -165,6 +165,9 @@
   <data name="Exception_ConditionForType_X_WithValue_X_IsNotSupported" xml:space="preserve">
     <value>Condition for type {0} with value {1} is not supported</value>
   </data>
+  <data name="Exception_CouldNotOpenADynamicPortForExclusiveUse" xml:space="preserve">
+    <value>Could not open a dynamic port for exclusive use</value>
+  </data>
   <data name="Exception_FailedToClearCacheFile_X_ForKey_X" xml:space="preserve">
     <value>Failed to clear cache file {0} for key {1}</value>
   </data>
@@ -182,6 +185,12 @@
   </data>
   <data name="Exception_Property_X_WithValue_X_MustBeGreaterThanOrEqualToProperty_X_WithValue_X" xml:space="preserve">
     <value>Property {0} with value {1} must be greater than or equal to {2} with value {3}</value>
+  </data>
+  <data name="Exception_ThereAreNoFreePortsWithinTheInputRange" xml:space="preserve">
+    <value>There are no free ports within the input range</value>
+  </data>
+  <data name="Exception_UnexpectedEndpointType" xml:space="preserve">
+    <value>Unexpected endpoint type</value>
   </data>
   <data name="Log_CacheDirectorCannotCompactToTargetSizeOf_X" xml:space="preserve">
     <value>The cache director could not compact the cache to target capacity of {Size}</value>

--- a/src/Outkeep.Core/Tcp/ITcpListenerWrapper.cs
+++ b/src/Outkeep.Core/Tcp/ITcpListenerWrapper.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Net;
 
-namespace Outkeep.Hosting
+namespace Outkeep.Core.Tcp
 {
     /// <summary>
     /// Wraps static calls to the <see cref="TcpListener"/> class to facilitate testing.

--- a/src/Outkeep.Core/Tcp/ITcpListenerWrapperFactory.cs
+++ b/src/Outkeep.Core/Tcp/ITcpListenerWrapperFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace Outkeep.Hosting
+﻿namespace Outkeep.Core.Tcp
 {
     public interface ITcpListenerWrapperFactory
     {

--- a/src/Outkeep.Core/Tcp/TcpHelper.cs
+++ b/src/Outkeep.Core/Tcp/TcpHelper.cs
@@ -1,9 +1,9 @@
-﻿using Outkeep.Hosting.Properties;
+﻿using Outkeep.Core.Properties;
 using System;
 using System.Net;
 using System.Net.Sockets;
 
-namespace Outkeep.Hosting
+namespace Outkeep.Core.Tcp
 {
     public sealed class TcpHelper
     {
@@ -54,7 +54,7 @@ namespace Outkeep.Hosting
                 }
             }
 
-            throw new InvalidOperationException(Resources.ThereAreNoFreePortsWithinTheInputRange);
+            throw new InvalidOperationException(Resources.Exception_ThereAreNoFreePortsWithinTheInputRange);
         }
 
         public int GetFreeDynamicPort()
@@ -70,12 +70,12 @@ namespace Outkeep.Hosting
                 }
                 else
                 {
-                    throw new InvalidOperationException(Resources.ExceptionUnexpectedEndpointType);
+                    throw new InvalidOperationException(Resources.Exception_UnexpectedEndpointType);
                 }
             }
             catch (SocketException ex)
             {
-                throw new InvalidOperationException(Resources.ExceptionCouldNotOpenADynamicPortForExclusiveUse, ex);
+                throw new InvalidOperationException(Resources.Exception_CouldNotOpenADynamicPortForExclusiveUse, ex);
             }
             finally
             {

--- a/src/Outkeep.Core/Tcp/TcpListenerWrapper.cs
+++ b/src/Outkeep.Core/Tcp/TcpListenerWrapper.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using System.Net.Sockets;
 
-namespace Outkeep.Hosting
+namespace Outkeep.Core.Tcp
 {
     /// <summary>
     /// Wraps static calls to the <see cref="TcpListener"/> class to facilitate testing.

--- a/src/Outkeep.Core/Tcp/TcpListenerWrapperFactory.cs
+++ b/src/Outkeep.Core/Tcp/TcpListenerWrapperFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace Outkeep.Hosting
+﻿namespace Outkeep.Core.Tcp
 {
     /// <summary>
     /// Default implementation of <see cref="ITcpListenerWrapperFactory"/>.

--- a/src/Outkeep.Hosting.Standalone/OutkeepHostingExtensions.cs
+++ b/src/Outkeep.Hosting.Standalone/OutkeepHostingExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using Orleans.Hosting;
-using Outkeep.Hosting;
+using Outkeep.Core.Tcp;
 using System;
 using System.Net;
 

--- a/src/Outkeep.Hosting/Properties/Resources.Designer.cs
+++ b/src/Outkeep.Hosting/Properties/Resources.Designer.cs
@@ -61,24 +61,6 @@ namespace Outkeep.Hosting.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not open a dynamic port for exclusive use.
-        /// </summary>
-        internal static string ExceptionCouldNotOpenADynamicPortForExclusiveUse {
-            get {
-                return ResourceManager.GetString("ExceptionCouldNotOpenADynamicPortForExclusiveUse", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unexpected endpoint type.
-        /// </summary>
-        internal static string ExceptionUnexpectedEndpointType {
-            get {
-                return ResourceManager.GetString("ExceptionUnexpectedEndpointType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Outkeep Server Started.
         /// </summary>
         internal static string LogOutkeepServerStarted {
@@ -111,15 +93,6 @@ namespace Outkeep.Hosting.Properties {
         internal static string LogOutkeepServerStopping {
             get {
                 return ResourceManager.GetString("LogOutkeepServerStopping", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to There are no free ports within the input range.
-        /// </summary>
-        internal static string ThereAreNoFreePortsWithinTheInputRange {
-            get {
-                return ResourceManager.GetString("ThereAreNoFreePortsWithinTheInputRange", resourceCulture);
             }
         }
     }

--- a/src/Outkeep.Hosting/Properties/Resources.resx
+++ b/src/Outkeep.Hosting/Properties/Resources.resx
@@ -117,12 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ExceptionCouldNotOpenADynamicPortForExclusiveUse" xml:space="preserve">
-    <value>Could not open a dynamic port for exclusive use</value>
-  </data>
-  <data name="ExceptionUnexpectedEndpointType" xml:space="preserve">
-    <value>Unexpected endpoint type</value>
-  </data>
   <data name="LogOutkeepServerStarted" xml:space="preserve">
     <value>Outkeep Server Started</value>
   </data>
@@ -134,8 +128,5 @@
   </data>
   <data name="LogOutkeepServerStopping" xml:space="preserve">
     <value>Outkeep Server Stopping</value>
-  </data>
-  <data name="ThereAreNoFreePortsWithinTheInputRange" xml:space="preserve">
-    <value>There are no free ports within the input range</value>
   </data>
 </root>

--- a/test/Outkeep.Api.Http.Tests/OutkeepHttpApiHostedServiceTests.cs
+++ b/test/Outkeep.Api.Http.Tests/OutkeepHttpApiHostedServiceTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Orleans;
+using Outkeep.Core.Tcp;
 using System;
 using System.Threading.Tasks;
 using Xunit;
@@ -15,10 +16,11 @@ namespace Outkeep.Api.Http.Tests
         public async Task Cycles()
         {
             // arrange
+            var port = TcpHelper.Default.GetFreeDynamicPort();
             var logger = new NullLogger<OutkeepHttpApiHostedService>();
             var options = new OutkeepHttpApiServerOptions
             {
-                ApiUri = new Uri("http://localhost:51234")
+                ApiUri = new Uri($"http://localhost:{port}")
             };
             var loggerProviders = new ILoggerProvider[] { NullLoggerProvider.Instance };
             var grainFactory = Mock.Of<IGrainFactory>();

--- a/test/Outkeep.Core.Tests/TcpHelperTests.cs
+++ b/test/Outkeep.Core.Tests/TcpHelperTests.cs
@@ -62,6 +62,24 @@ namespace Outkeep.Core.Tests
         }
 
         [Fact]
+        public void GetsFirstFreePortWithSingleParameter()
+        {
+            // arrange
+            var factory = Mock.Of<ITcpListenerWrapperFactory>();
+            Mock.Get(factory).Setup(x => x.Create(1, true).Start()).Throws(new SocketException());
+            Mock.Get(factory).Setup(x => x.Create(2, true).Start()).Throws(new SocketException());
+            Mock.Get(factory).Setup(x => x.Create(3, true).Stop()).Throws(new SocketException());
+
+            var helper = new TcpHelper(factory);
+
+            // act
+            var port = helper.GetFreePort(1);
+
+            // assert
+            Assert.Equal(3, port);
+        }
+
+        [Fact]
         public void ThrowsOnNoFreePort()
         {
             // arrange

--- a/test/Outkeep.Core.Tests/TcpHelperTests.cs
+++ b/test/Outkeep.Core.Tests/TcpHelperTests.cs
@@ -145,5 +145,19 @@ namespace Outkeep.Core.Tests
         {
             Assert.NotNull(TcpHelper.Default);
         }
+
+        [Fact]
+        public void GetFreePortThrowsOnPortGreaterThanMaxPort()
+        {
+            // arrange
+            var helper = new TcpHelper(TcpListenerWrapperFactory.Default);
+            var end = IPEndPoint.MaxPort + 1;
+
+            // act
+            void action() => helper.GetFreePort(1, IPEndPoint.MaxPort + 1);
+
+            // assert
+            Assert.Throws<ArgumentOutOfRangeException>(nameof(end), action);
+        }
     }
 }

--- a/test/Outkeep.Core.Tests/TcpHelperTests.cs
+++ b/test/Outkeep.Core.Tests/TcpHelperTests.cs
@@ -1,11 +1,12 @@
 ﻿using Moq;
-using Outkeep.Hosting.Properties;
+using Outkeep.Core.Properties;
+using Outkeep.Core.Tcp;
 using System;
 using System.Net;
 using System.Net.Sockets;
 using Xunit;
 
-namespace Outkeep.Hosting.Tests
+namespace Outkeep.Core.Tests
 {
     public class TcpHelperTests
     {
@@ -73,7 +74,7 @@ namespace Outkeep.Hosting.Tests
 
             // act and assert
             var error = Assert.Throws<InvalidOperationException>(() => helper.GetFreePort(1, 3));
-            Assert.Equal(Resources.ThereAreNoFreePortsWithinTheInputRange, error.Message);
+            Assert.Equal(Resources.Exception_ThereAreNoFreePortsWithinTheInputRange, error.Message);
         }
 
         [Fact]
@@ -103,7 +104,7 @@ namespace Outkeep.Hosting.Tests
 
             // act and assert
             var error = Assert.Throws<InvalidOperationException>(() => helper.GetFreeDynamicPort());
-            Assert.Equal(Resources.ExceptionUnexpectedEndpointType, error.Message);
+            Assert.Equal(Resources.Exception_UnexpectedEndpointType, error.Message);
         }
 
         [Fact]
@@ -117,7 +118,7 @@ namespace Outkeep.Hosting.Tests
 
             // act and assert
             var error = Assert.Throws<InvalidOperationException>(() => helper.GetFreeDynamicPort());
-            Assert.Equal(Resources.ExceptionCouldNotOpenADynamicPortForExclusiveUse, error.Message);
+            Assert.Equal(Resources.Exception_CouldNotOpenADynamicPortForExclusiveUse, error.Message);
             Assert.Same(ex, error.InnerException);
         }
 

--- a/test/Outkeep.Core.Tests/TcpHelperTests.cs
+++ b/test/Outkeep.Core.Tests/TcpHelperTests.cs
@@ -147,7 +147,21 @@ namespace Outkeep.Core.Tests
         }
 
         [Fact]
-        public void GetFreePortThrowsOnPortGreaterThanMaxPort()
+        public void GetFreePortThrowsOnStartPortGreaterThanMaxPort()
+        {
+            // arrange
+            var helper = new TcpHelper(TcpListenerWrapperFactory.Default);
+            var start = IPEndPoint.MaxPort + 1;
+
+            // act
+            void action() => helper.GetFreePort(start);
+
+            // assert
+            Assert.Throws<ArgumentOutOfRangeException>(nameof(start), action);
+        }
+
+        [Fact]
+        public void GetFreePortThrowsOnEndPortGreaterThanMaxPort()
         {
             // arrange
             var helper = new TcpHelper(TcpListenerWrapperFactory.Default);

--- a/test/Outkeep.Core.Tests/TcpListenerWrapperTests.cs
+++ b/test/Outkeep.Core.Tests/TcpListenerWrapperTests.cs
@@ -3,7 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using Xunit;
 
-namespace Outkeep.Hosting.Tests
+namespace Outkeep.Core.Tests
 {
     public class TcpListenerWrapperTests
     {

--- a/test/Outkeep.Hosting.Tests/TcpListenerWrapperTests.cs
+++ b/test/Outkeep.Hosting.Tests/TcpListenerWrapperTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using Outkeep.Core.Tcp;
+using System.Net;
 using System.Net.Sockets;
 using Xunit;
 


### PR DESCRIPTION
This allows use of the TcpHelper in all unit tests without affecting features